### PR TITLE
chore: migrate from google-generativeai to google-genai SDK

### DIFF
--- a/podcast/requirements.txt
+++ b/podcast/requirements.txt
@@ -1,4 +1,4 @@
-google-generativeai
+google-genai
 python-dotenv
 requests
 edge-tts

--- a/podcast/script.py
+++ b/podcast/script.py
@@ -2,7 +2,8 @@ import os
 import json
 import subprocess
 import requests
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 import asyncio
 from pathlib import Path
 from datetime import datetime
@@ -61,13 +62,7 @@ def generate_script(articles):
         print("No articles to summarize.")
         return None
 
-    genai.configure(api_key=gemini_api_key)
-    
-    # Using Gemini Flash for reliability and speed
-    model = genai.GenerativeModel(
-        model_name="gemini-flash-latest",
-        system_instruction=SYSTEM_PROMPT
-    )
+    client = genai.Client(api_key=gemini_api_key)
 
     # Prepare article content for the prompt
     articles_payload = []
@@ -81,7 +76,13 @@ def generate_script(articles):
     prompt = f"Here are the articles to discuss today:\n\n{json.dumps(articles_payload, indent=2)}"
 
     try:
-        response = model.generate_content(prompt)
+        response = client.models.generate_content(
+            model="gemini-2.0-flash",
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                system_instruction=SYSTEM_PROMPT,
+            ),
+        )
         
         # Clean up the response text in case Gemini adds markdown code blocks
         content = response.text.strip()

--- a/podcast/tests/test_script.py
+++ b/podcast/tests/test_script.py
@@ -51,11 +51,10 @@ class TestGenerateScript:
 
     def test_parses_clean_json_response(self, monkeypatch):
         monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = json.dumps(SAMPLE_SCRIPT)
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value.text = json.dumps(SAMPLE_SCRIPT)
 
-        with patch("script.genai.configure"), \
-             patch("script.genai.GenerativeModel", return_value=mock_model):
+        with patch("script.genai.Client", return_value=mock_client):
             result = script.generate_script(SAMPLE_ARTICLES)
 
         assert result == SAMPLE_SCRIPT
@@ -64,22 +63,20 @@ class TestGenerateScript:
         """Gemini sometimes returns ```json ... ``` — we must strip that."""
         monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
         fenced = f"```json\n{json.dumps(SAMPLE_SCRIPT)}\n```"
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = fenced
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value.text = fenced
 
-        with patch("script.genai.configure"), \
-             patch("script.genai.GenerativeModel", return_value=mock_model):
+        with patch("script.genai.Client", return_value=mock_client):
             result = script.generate_script(SAMPLE_ARTICLES)
 
         assert result == SAMPLE_SCRIPT
 
     def test_returns_none_on_gemini_exception(self, monkeypatch):
         monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
-        mock_model = MagicMock()
-        mock_model.generate_content.side_effect = Exception("API error")
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = Exception("API error")
 
-        with patch("script.genai.configure"), \
-             patch("script.genai.GenerativeModel", return_value=mock_model):
+        with patch("script.genai.Client", return_value=mock_client):
             result = script.generate_script(SAMPLE_ARTICLES)
 
         assert result is None


### PR DESCRIPTION
## Summary

Migrates the podcast script generation from the deprecated `google-generativeai` package to the new `google-genai` SDK before its August 31, 2025 EOL.

## Changes

- **`podcast/requirements.txt`** — `google-generativeai` → `google-genai`
- **`podcast/script.py`** — Updated `generate_script()`:
  - `import google.generativeai as genai` → `from google import genai` + `from google.genai import types`
  - `genai.configure() + GenerativeModel(...)` → `genai.Client(api_key=...) + client.models.generate_content(...)`
  - `system_instruction` now passed via `types.GenerateContentConfig`
  - Model alias `gemini-flash-latest` → `gemini-2.0-flash`
- **`podcast/tests/test_script.py`** — Mocks updated to patch `genai.Client` instead of `genai.configure + GenerativeModel`

## Testing

All 33 tests pass, with no `FutureWarning` from `google-generativeai`.