### PR TITLE
Fix Android share sheet not uploading to cloud

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -30,6 +30,7 @@ class StashApp {
     // Skip auth - go straight to main screen
     this.showMainScreen();
     this.loadData();
+    this.syncPendingShares();
 
     this.bindEvents();
     this.setupRealtime();
@@ -668,22 +669,55 @@ class StashApp {
     `;
   }
 
+  async syncPendingShares() {
+    if (!navigator.onLine) return;
+    let pending;
+    try {
+      pending = await window.StashDB.getPendingShares();
+    } catch (e) {
+      return;
+    }
+    if (!pending.length) return;
+
+    let synced = 0;
+    for (const { key, data } of pending) {
+      try {
+        const res = await fetch(`${CONFIG.SUPABASE_URL}/rest/v1/saves`, {
+          method: 'POST',
+          headers: {
+            'apikey': CONFIG.SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${CONFIG.SUPABASE_ANON_KEY}`,
+            'Content-Type': 'application/json',
+            'Prefer': 'return=minimal',
+          },
+          body: JSON.stringify(data),
+        });
+        if (res.ok) {
+          await window.StashDB.deletePendingShare(key);
+          synced++;
+        }
+      } catch (e) {
+        // Leave in queue, try again next time
+      }
+    }
+    if (synced > 0) {
+      this.loadSaves();
+    }
+  }
+
   updateOnlineStatus() {
     const toast = document.getElementById('toast');
     const msg = document.getElementById('toast-message');
-    
+
     if (navigator.onLine) {
         msg.textContent = "Back online";
         toast.classList.remove('hidden');
         setTimeout(() => toast.classList.add('hidden'), 3000);
-        
-        // Synced? Maybe trigger a reload or sync
-        // For MVP, just let user know.
-        // If we want to be fancy, we could try to sync pending items here.
+
+        this.syncPendingShares();
     } else {
         msg.textContent = "You are offline. Showing cached content.";
         toast.classList.remove('hidden');
-        // Keep it visible? Or hide after 5s?
         setTimeout(() => toast.classList.add('hidden'), 5000);
     }
   }

--- a/web/db.js
+++ b/web/db.js
@@ -73,5 +73,36 @@ window.StashDB = {
              transaction.oncomplete = () => resolve();
              transaction.onerror = () => reject(transaction.error);
         });
+    },
+
+    async getPendingShares() {
+        const db = await dbPromise;
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction([STORE_PENDING], 'readonly');
+            const store = transaction.objectStore(STORE_PENDING);
+            const request = store.getAll();
+            const keyRequest = store.getAllKeys();
+            let results, keys;
+            request.onsuccess = () => {
+                results = request.result;
+                if (keys !== undefined) resolve(results.map((r, i) => ({ key: keys[i], data: r })));
+            };
+            keyRequest.onsuccess = () => {
+                keys = keyRequest.result;
+                if (results !== undefined) resolve(results.map((r, i) => ({ key: keys[i], data: r })));
+            };
+            request.onerror = () => reject(request.error);
+        });
+    },
+
+    async deletePendingShare(key) {
+        const db = await dbPromise;
+        const transaction = db.transaction([STORE_PENDING], 'readwrite');
+        const store = transaction.objectStore(STORE_PENDING);
+        store.delete(key);
+        return new Promise((resolve, reject) => {
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(transaction.error);
+        });
     }
 };

--- a/web/save.html
+++ b/web/save.html
@@ -249,6 +249,7 @@
           method: 'POST',
           headers: {
             'apikey': CONFIG.SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${CONFIG.SUPABASE_ANON_KEY}`,
             'Content-Type': 'application/json',
             'Prefer': 'return=minimal',
           },


### PR DESCRIPTION
## Summary

- **Missing `Authorization` header** in `save.html` caused every share-sheet save to be silently rejected by Supabase RLS, falling back to the offline queue instead of saving to the cloud
- **Pending queue was never synced** — items saved to IndexedDB while "offline" were never uploaded; added `getPendingShares`/`deletePendingShare` to `db.js` and implemented `syncPendingShares()` in `app.js`
- `syncPendingShares()` is now called on app startup and whenever the device comes back online

## Test plan

- [ ] Share a URL from Chrome on Android to the Stash PWA — animation should show "Saved!" (not "Saved to pending queue!")
- [ ] Open the main Stash app and confirm the item appears in the list
- [ ] Save while offline, then reconnect — item should automatically sync and appear

https://claude.ai/code/session_01WgxxrUffuvF1ZD2iXw89GK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgxxrUffuvF1ZD2iXw89GK)_